### PR TITLE
Fixed abilities

### DIFF
--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -399,6 +399,6 @@
 
 #define SKIP_FRONT_ANIM (1 << 7)
 
-#define NUM_ABILITY_SLOTS 2
+#define NUM_ABILITY_SLOTS 3
 
 #endif // GUARD_CONSTANTS_POKEMON_H

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -55,7 +55,7 @@ struct PokemonSubstruct3
  /* 0x05 */ u32 spAttackIV:5;
  /* 0x06 */ u32 spDefenseIV:5;
  /* 0x07 */ u32 isEgg:1;
- /* 0x07 */ u32 abilityNum:1;
+ /* 0x07 */ u32 abilityNum:2;
 
  /* 0x08 */ u32 coolRibbon:3;
  /* 0x08 */ u32 beautyRibbon:3;

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4200,10 +4200,25 @@ u8 GetMonsStateToDoubles_2(void)
 
 u16 GetAbilityBySpecies(u16 species, u8 abilityNum)
 {
-    if (abilityNum)
-        gLastUsedAbility = gBaseStats[species].abilities[1];
+    int i;
+
+    if (abilityNum < NUM_ABILITY_SLOTS)
+        gLastUsedAbility = gBaseStats[species].abilities[abilityNum];
     else
-        gLastUsedAbility = gBaseStats[species].abilities[0];
+        gLastUsedAbility = ABILITY_NONE;
+
+    if (abilityNum >= 2) // if abilityNum is empty hidden ability, look for other hidden abilities
+    {
+        for (i = 2; i < NUM_ABILITY_SLOTS && gLastUsedAbility == ABILITY_NONE; i++)
+        {
+            gLastUsedAbility = gBaseStats[species].abilities[i];
+        }
+    }
+
+    for (i = 0; i < NUM_ABILITY_SLOTS && gLastUsedAbility == ABILITY_NONE; i++) // look for any non-empty ability
+    {
+        gLastUsedAbility = gBaseStats[species].abilities[i];
+    }
 
     return gLastUsedAbility;
 }


### PR DESCRIPTION
## Description
-Made the code use NUM_ABILITY_SLOTS to determine the number of abilities a Pokémon species can have.
-Fixed the bit size of the `abilityNum` variable located in the `PokemonSubstruct3`. 1 bit can only generate Abilities 0 and 1, which is no good when you can have an Ability 2.
-Updated GetAbilityBySpecies so it can recognize Ability 2s and beyond, copy-pasted from a modern copy of the expansion.
 * Note: Since this project doesn't have a `NUM_NORMAL_ABILITY_SLOTS`, I just hardcoded it to 2 which is the value it stands for in RHH and the max. amount of normal abilities a Pokémon can have.

## **Discord contact info**
Lunos#4026